### PR TITLE
Add doc.go at the root of the repo

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2016 Bracket Computing, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// https://github.com/brkt/brkt-cli/blob/master/LICENSE
+//
+// or in the "license" file accompanying this file. This file is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and
+// limitations under the License.
+package vmware
+
+// Package vmware contains code and utilities that are used for integration
+// between the Bracket Computing service and VMware products.


### PR DESCRIPTION
Add an empty source file at the root of the repo.  Without this file,
users will see an error when they run go get on the root of the repo:

~$ go get github.com/brkt/vcenter-agent
package github.com/brkt/vcenter-agent: no buildable Go source files in
/tmp/go/src/github.com/brkt/vcenter-agent